### PR TITLE
Fix gpx case with empty track segment element. Fix newer phpunit version incompatability.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nbproject/
+.idea
 /vendor/
 /composer.lock

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,11 @@
         }
     ],
     "require": {
-        "php": ">=7.0.4"
+        "php": ">=7.0.4",
+        "ext-simplexml": "*"
     },
     "require-dev": {
-      "phpunit/phpunit": "dev-master"  
+      "phpunit/phpunit": "^7.4"
     },
     "autoload": {
         "psr-4": { "Waddle\\": "src/" }

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -20,7 +20,7 @@ class Activity
     
     /**
      * Set the activity type
-     * @param type $type
+     * @param string $type
      * @return $this
      */
     public function setType($type){
@@ -30,8 +30,8 @@ class Activity
     
     /**
      * Get the start time in a particular format
-     * @param type $format
-     * @return type
+     * @param string $format
+     * @return string
      */
     public function getStartTime($format){
         return ($this->startTime instanceof \DateTime) ? $this->startTime->format($format) : $this->startTime;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -9,12 +9,12 @@ abstract class Parser
 
     /**
      * Check if file is available
-     * @param $file
+     * @param string $pathname
      * @throws \Exception
      */
-    protected function checkForFile($file) {
-        if (!is_file($file)){
-            throw new \Exception("Could not load file: {$file}");
+    protected function checkForFile($pathname) {
+        if (!is_file($pathname)){
+            throw new \Exception("Could not load file: {$pathname}");
         }
     }
     

--- a/src/Parsers/GPXParser.php
+++ b/src/Parsers/GPXParser.php
@@ -12,21 +12,21 @@ class GPXParser extends Parser
     
     /**
      * Parse the GPX file
-     * @param type $file
+     * @param string $pathname
      * @return Activity
      * @throws \Exception
      */
-    public function parse($file)
+    public function parse($pathname)
     {
 
         // Check that the file exists
-        $this->checkForFile($file);
+        $this->checkForFile($pathname);
         
         // Create a new activity instance
         $activity = new Activity();
         
         // Load the XML in the TCX file
-        $data = simplexml_load_file($file);
+        $data = simplexml_load_file($pathname);
         if (!isset($data->trk)){
             throw new \Exception("Unable to find valid activity in file contents");
         }
@@ -41,6 +41,11 @@ class GPXParser extends Parser
         // There should only be 1 trkseg, but they are stored in an array just in case this ever changes
         foreach($activityNode->trkseg as $lapNode)
         {
+            if(!$lapNode->trkpt){
+                // In some cases there can be an empty lap node
+                continue;
+            }
+
             $activity->addLap( $this->parseLap($lapNode) );
         }
                 
@@ -52,7 +57,7 @@ class GPXParser extends Parser
     
     /**
      * Parse the lap XML (trkseg)
-     * @param type $lapNode
+     * @param \SimpleXMLElement $lapNode
      * @return \Waddle\Lap
      */
     protected function parseLap($lapNode)

--- a/src/TrackPoint.php
+++ b/src/TrackPoint.php
@@ -118,7 +118,7 @@ class TrackPoint
     
     /**
      * Set the speed
-     * @param type $val
+     * @param float $val
      * @return $this
      */
     public function setSpeed($val){

--- a/tests/run.gpx
+++ b/tests/run.gpx
@@ -5703,5 +5703,6 @@
                 <time>2017-05-27T08:36:44.000Z</time>
             </trkpt>
         </trkseg>
+        <trkseg/>
     </trk>
 </gpx>


### PR DESCRIPTION
When exporting GPX from Endomondo, there may be cases where an empty track segment file exists, which will cause the parsing to fail. This fix skips empty segments.